### PR TITLE
Use runtime TCP_CORK lookup with Socket::Const fallback

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+1.63
+    -- Use runtime TCP_CORK lookup with Socket::Const fallback instead of hard-coded value
+
 1.62
     -- Fixed rt21751: test hangs on MSWin32 (Andy Melnikov)
     -- Fixed rt34188: Tests use perlbal management port - so fail
@@ -12,7 +15,6 @@
     -- Fixed rt129484: deal with EINTR in IO::Poll path
     -- Fixed rt72670: simple optimization by caching pack
        (nicolas.rochelemagne@cpanel.net, bitcard@miuku.net)
-    -- Use runtime TCP_CORK lookup with Socket::Const fallback instead of hard-coded value
 
 1.61 (2008-11-27)
     -- IPv6 support.  At least enough to get Perlbal going.

--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@
     -- Fixed rt129484: deal with EINTR in IO::Poll path
     -- Fixed rt72670: simple optimization by caching pack
        (nicolas.rochelemagne@cpanel.net, bitcard@miuku.net)
+    -- Use runtime TCP_CORK lookup with Socket::Const fallback instead of hard-coded value
 
 1.61 (2008-11-27)
     -- IPv6 support.  At least enough to get Perlbal going.

--- a/lib/Danga/Socket.pm
+++ b/lib/Danga/Socket.pm
@@ -133,7 +133,11 @@ use Errno  qw(EINPROGRESS EWOULDBLOCK EISCONN ENOTSOCK
 use Socket qw(IPPROTO_TCP);
 use Carp   qw(croak confess);
 
-use constant TCP_CORK => ($^O eq "linux" ? 3 : 0); # FIXME: not hard-coded (Linux-specific too)
+# try to discover TCP_CORK at runtime, falling back to old behavior
+use constant TCP_CORK =>
+    eval { Socket::TCP_CORK() }
+    || eval { require Socket::Const; Socket::Const::TCP_CORK() }
+    || ($^O eq 'linux' ? 3 : 0);
 use constant DebugLevel => 0;
 
 use constant POLLIN        => 1;


### PR DESCRIPTION
## Summary
- discover `TCP_CORK` at runtime, falling back to `Socket::Const` and numeric defaults
- document TCP_CORK runtime lookup

## Testing
- `prove -lr t`

------
https://chatgpt.com/codex/tasks/task_e_68aefdb87d34832b870e231c55c5d095